### PR TITLE
Windows: don't pass '-std=c++11', unknown by MVSC

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,10 +75,11 @@ kwargs = dict(
     libraries=LIBRARIES,
     language="c++",
 )
-if platform.system() == "Darwin":
+plat = platform.system()
+if plat == "Darwin":
     kwargs["extra_compile_args"] = ["-std=c++11", "-stdlib=libc++"]
     kwargs["extra_link_args"] = ["-stdlib=libc++"]
-else:
+elif plat != "Windows":
     kwargs["extra_compile_args"] = ["-std=c++11"]
 
 ext = [


### PR DESCRIPTION
`cl : Command line warning D9002 : ignoring unknown option '-std=c++11'`

See https://stackoverflow.com/q/66386066/7954504 and
https://github.com/bsolomon1124/pycld3/issues/24.