### PR TITLE
[breaking] [build] Switch from HAS_CYTHON -> USE_CYTHON

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           name: Build manylinux1 wheels
           command: |
             IMAGE_NAME='bsolomon1124/manylinux1_protobuf:latest'
-            docker container run --rm --volume "${PWD}":/io "$IMAGE_NAME" /io/build-manylinux-whls.sh
+            docker container run --rm --volume "${PWD}":/io --workdir /io "$IMAGE_NAME" /io/build-manylinux-whls.sh
       - store_artifacts:
           path: wheelhouse/
       - store_artifacts:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -29,6 +29,7 @@ jobs:
         python -m pip install --upgrade --disable-pip-version-check delocate
     - name: Build wheels
       run: |
+        USE_CYTHON=1 python setup.py --quiet build
         python -m pip wheel -v --no-deps --wheel-dir wheels/ .
     - name: Repair wheels
       run: |
@@ -42,3 +43,32 @@ jobs:
       with:
         name: System information
         path: system_info.log
+  sdist:
+    name: Build source distribution (sdist)
+    runs-on: [ubuntu-latest]
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.7]
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y --no-install-recommends g++ protobuf-compiler libprotobuf-dev
+        python -m pip install --upgrade --disable-pip-version-check -r requirements-dev.txt
+    - name: Build sdist
+      env:
+        USE_CYTHON: 1
+      run: |
+        python setup.py --verbose build
+        python setup.py --verbose sdist
+    - name: Upload artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: Source distribution
+        path: dist/

--- a/build-manylinux-whls.sh
+++ b/build-manylinux-whls.sh
@@ -30,6 +30,7 @@ for PYBIN in /opt/python/*/bin; do
       "${PYBIN}/pip" install -U pip wheel setuptools
       "${PYBIN}/pip" install --disable-pip-version-check cryptography --only-binary cryptography
       "${PYBIN}/pip" install --disable-pip-version-check --upgrade -r /io/requirements-dev.txt
+      USE_CYTHON=1 "${PYBIN}/python" setup.py --quiet build
       "${PYBIN}/pip" wheel -v -w wheelhouse/ /io/
       ;;
   esac


### PR DESCRIPTION
Make Cython compilation from pyx optional even if the installing
user has Cython. Allow user to pass USE_CYTHON=1 to build with Cython.

Related to: https://github.com/bsolomon1124/pycld3/issues/24