### PR TITLE
Fix deprecated parameter name

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-license_file = LICENSE
+license_files = LICENSE


### PR DESCRIPTION
The `license_file` parameter is deprecated, use [license_files](url) instead.
      
By 2023-Oct-30, you need to update your project and remove deprecated calls or your builds will no longer be supported.
